### PR TITLE
Updates cli-tools image

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up tags
         id: setup
         run: |
-          TAG_BASE="quay.io/ibmgaragecloud/cli-tools"
+          TAG_BASE="quay.io/cloud-native-toolkit/cli-tools"
 
           BRANCH=${GITHUB_REF#refs/heads/}
           TAG="${{ github.event.release.tag_name }}"
@@ -32,7 +32,7 @@ jobs:
           else
             echo "Running against branch: ${BRANCH}"
             TAGS="${TAG_BASE}:${BRANCH}"
-            if [[ "${BRANCH}" == "v14" ]]; then
+            if [[ "${BRANCH}" == "v1.1" ]]; then
               TAGS="${TAGS},${TAG_BASE}:latest"
             fi
           fi
@@ -56,8 +56,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
+          username: ${{ secrets.QUAY_CNTK_USERNAME }}
+          password: ${{ secrets.QUAY_CNTK_TOKEN }}
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: Verify and release module
 # events but only for the master branch
 on:
   push:
-    branches: [ v0.15 ]
+    branches: [ v1.1 ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,9 @@ ENV HOME /home/devops
 
 # Create devops user
 RUN useradd -u 10000 -g root -G sudo -d ${HOME} -m devops && \
-    usermod --password $(echo password | openssl passwd -1 -stdin) devops
+    usermod --password $(echo password | openssl passwd -1 -stdin) devops && \
+    mkdir -p /workspaces && \
+    chown -R 10000:0 /workspaces
 
 USER devops
 WORKDIR ${HOME}
@@ -109,5 +111,7 @@ RUN wget -q -O ./yq $(wget -q -O - https://api.github.com/repos/mikefarah/yq/rel
 RUN wget -q -O ./yq4 $(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/tags/v4.16.1 | jq -r '.assets[] | select(.name == "yq_linux_amd64") | .browser_download_url') && \
     chmod +x ./yq4 && \
     sudo mv ./yq4 /usr/bin/yq4
+
+VOLUME /workspaces
 
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
- Adds a /workspaces directory with `devops` user as the owner and exposes as a volume - closes #31
- Makes v1.1 the default branch by updating the release workflow trigger and the image tagged with `latest` - closes #29
- Updates the tag_name to quay.io/cloud-native-toolkit/cli-tools and updates credentials - closes #30

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>