### PR TITLE
Updates terraform to v1.1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/hashicorp/terraform:1.1.7
+FROM docker.io/hashicorp/terraform:1.1.9
 
 ENV OPENSHIFT_CLI_VERSION 4.7
 


### PR DESCRIPTION
- Updates base image to v1.1.9 to pick up latest terraform cli

closes #36

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>