### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
   shadow \
   bash \
   openssl \
+  openssh-keygen \
   ca-certificates \
   perl \
   openvpn \


### PR DESCRIPTION
added `openssh-keygen`.   fixes https://github.com/cloud-native-toolkit/software-everywhere/issues/261

(cherry picked from commit f1ba7ed78d35e642c31ea7e0227b181b54553265)